### PR TITLE
Changed geometry to tracer concentration within box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.o
+*.so
+*.exe
+build*
+*.root
+~*
+*~
+*.swp
+.nfs*

--- a/include/DetectorConstruction.hh
+++ b/include/DetectorConstruction.hh
@@ -38,18 +38,6 @@ class G4VPhysicalVolume;
 class G4GlobalMagFieldMessenger;
 
 /// Detector construction class to define materials and geometry.
-/// The calorimeter is a box made of a given number of layers. A layer consists
-/// of an absorber plate and of a detection gap. The layer is replicated.
-///
-/// Four parameters define the geometry of the calorimeter :
-///
-/// - the thickness of an absorber plate,
-/// - the thickness of a gap,
-/// - the number of layers,
-/// - the transverse size of the calorimeter (the input face is a square).
-///
-/// In addition a transverse uniform magnetic field is defined 
-/// via G4GlobalMagFieldMessenger class.
 
 class DetectorConstruction : public G4VUserDetectorConstruction
 {
@@ -59,12 +47,12 @@ class DetectorConstruction : public G4VUserDetectorConstruction
 
   public:
     virtual G4VPhysicalVolume* Construct();
-    virtual void ConstructSDandField();
 
     // get methods
     //
-    const G4VPhysicalVolume* GetWorldPV() const;
-    const G4VPhysicalVolume* GetTargetPV() const;
+    const G4VPhysicalVolume* GetWorldPV() const { return fWorldPV; }
+    const G4VPhysicalVolume* GetTargetPV() const { return fTargetPV; }
+    const G4VPhysicalVolume* GetBoxPV() const { return fBoxPV; }
      
   private:
     // methods
@@ -74,25 +62,13 @@ class DetectorConstruction : public G4VUserDetectorConstruction
   
     // data members
     //
-    static G4ThreadLocal G4GlobalMagFieldMessenger*  fMagFieldMessenger; 
-                                      // magnetic field messenger
      
     G4VPhysicalVolume*   fWorldPV;  // the world physical volume
+    G4VPhysicalVolume*   fBoxPV;    // the main physical volume (box)
     G4VPhysicalVolume*   fTargetPV; // the target physical volume
     
     G4bool  fCheckOverlaps; // option to activate checking of volumes overlaps
 };
-
-// inline functions
-
-inline const G4VPhysicalVolume* DetectorConstruction::GetWorldPV() const { 
-  return fWorldPV; 
-}
-
-inline const G4VPhysicalVolume* DetectorConstruction::GetTargetPV() const  { 
-  return fTargetPV; 
-}
-     
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 

--- a/src/RunAction.cc
+++ b/src/RunAction.cc
@@ -71,6 +71,9 @@ RunAction::RunAction()
   analysisManager->CreateNtupleDColumn("energy");
   analysisManager->CreateNtupleDColumn("time");
   analysisManager->CreateNtupleIColumn("particle");
+  analysisManager->CreateNtupleDColumn("vertex_x");
+  analysisManager->CreateNtupleDColumn("vertex_y");
+  analysisManager->CreateNtupleDColumn("vertex_z");
   analysisManager->FinishNtuple();
 }
 

--- a/src/SteppingAction.cc
+++ b/src/SteppingAction.cc
@@ -70,11 +70,13 @@ void SteppingAction::UserSteppingAction(const G4Step* step)
   G4VPhysicalVolume* secondVolume 
     = step->GetPostStepPoint()->GetTouchableHandle()->GetVolume();
   
+  G4Track* track = step->GetTrack();
+
   // energy deposit
   //G4double edep = step->GetTotalEnergyDeposit();
   G4double ekin = step->GetPreStepPoint()->GetKineticEnergy();
   G4double time = step->GetPreStepPoint()->GetGlobalTime();
-  G4String particleName = step->GetTrack()->GetParticleDefinition()->GetParticleName();
+  G4String particleName = track->GetParticleDefinition()->GetParticleName();
   G4int particle;
   if(particleName == "gamma")        particle = 1;
   else if(particleName == "proton")  particle = 2;
@@ -86,30 +88,46 @@ void SteppingAction::UserSteppingAction(const G4Step* step)
   else if(particleName == "O16")     particle = 8; 
   else particle = 0; 
 
-  G4Track* track = step->GetTrack();
-  if(particleName == "e-") track->SetTrackStatus(fKillTrackAndSecondaries);
+  //if(particleName == "e-") track->SetTrackStatus(fKillTrackAndSecondaries);
 
-  if( firstVolume == fDetConstruction->GetTargetPV() && secondVolume == fDetConstruction->GetWorldPV() ) {
+  // vertex
+  G4ThreeVector vertex = track->GetVertexPosition();
+
+  // particles leaving the box
+  if( firstVolume == fDetConstruction->GetBoxPV() && secondVolume == fDetConstruction->GetWorldPV() ) {
     G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();
     analysisManager->FillNtupleDColumn(0, ekin/MeV);
     analysisManager->FillNtupleDColumn(1, time/ms);
     analysisManager->FillNtupleIColumn(2, particle);
+	 analysisManager->FillNtupleDColumn(3, vertex.x()/mm);
+	 analysisManager->FillNtupleDColumn(4, vertex.y()/mm);
+	 analysisManager->FillNtupleDColumn(5, vertex.z()/mm);
     analysisManager->AddNtupleRow();
   }
 
-  // step length
-  //G4double stepLength = 0.;
-  //if ( step->GetTrack()->GetDefinition()->GetPDGCharge() != 0. ) {
-  //  stepLength = step->GetStepLength();
-  //}
-      
-  //if ( volume == fDetConstruction->GetAbsorberPV() ) {
-  //  fEventAction->AddAbs(edep,stepLength);
-  //}
-  
-  //if ( volume == fDetConstruction->GetGapPV() ) {
-  //  fEventAction->AddGap(edep,stepLength);
-  //}
+  // particles entering the target
+  if( firstVolume == fDetConstruction->GetBoxPV() && secondVolume == fDetConstruction->GetTargetPV() ) {
+    G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();
+    analysisManager->FillNtupleDColumn(0, ekin/MeV);
+    analysisManager->FillNtupleDColumn(1, time/ms);
+    analysisManager->FillNtupleIColumn(2, 10+particle);
+	 analysisManager->FillNtupleDColumn(3, vertex.x()/mm);
+	 analysisManager->FillNtupleDColumn(4, vertex.y()/mm);
+	 analysisManager->FillNtupleDColumn(5, vertex.z()/mm);
+    analysisManager->AddNtupleRow();
+  }
+
+  // particles leaving the target
+  if( firstVolume == fDetConstruction->GetTargetPV() && secondVolume == fDetConstruction->GetBoxPV() ) {
+    G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();
+    analysisManager->FillNtupleDColumn(0, ekin/MeV);
+    analysisManager->FillNtupleDColumn(1, time/ms);
+    analysisManager->FillNtupleIColumn(2, 20+particle);
+	 analysisManager->FillNtupleDColumn(3, vertex.x()/mm);
+	 analysisManager->FillNtupleDColumn(4, vertex.y()/mm);
+	 analysisManager->FillNtupleDColumn(5, vertex.z()/mm);
+    analysisManager->AddNtupleRow();
+  }
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/waterTank.cc
+++ b/waterTank.cc
@@ -40,6 +40,7 @@
 #include "G4UImanager.hh"
 #include "G4UIcommand.hh"
 #include "FTFP_BERT.hh"
+#include "QGSP_BIC.hh"
 
 #include "Randomize.hh"
 
@@ -114,7 +115,8 @@ int main(int argc,char** argv)
   DetectorConstruction* detConstruction = new DetectorConstruction();
   runManager->SetUserInitialization(detConstruction);
 
-  G4VModularPhysicsList* physicsList = new FTFP_BERT;
+  //G4VModularPhysicsList* physicsList = new FTFP_BERT;
+  G4VModularPhysicsList* physicsList = new QGSP_BIC;
   runManager->SetUserInitialization(physicsList);
     
   ActionInitialization* actionInitialization


### PR DESCRIPTION
- There is now a target of the main material (e.g. water or tissue), mixed with a given concentration of tracer (e.g 98Tc), within a box of just the main material.
- In addition to particles leaving the main box (particle 0-9), we also write out particles entering the target (particle 10-19), or leaving it (particle 20-29).
- In addition to energy, time, and particle, we now also write vertex_x, vertex_y, vertex_z to the tree. These are the coordinates of the vertex of the track.
- Removed some of the old comments.
- Switched physisc list from FTFP_BERT to QGSP_BIC, which has at least some of the characteristic gamma-rays, even though the population of these gamma-rays might be off.