### PR TITLE
Changed to writing events

### DIFF
--- a/include/EventAction.hh
+++ b/include/EventAction.hh
@@ -34,45 +34,29 @@
 #include "G4UserEventAction.hh"
 #include "globals.hh"
 
+#include "RunAction.hh"
+
 /// Event action class
-///
-/// It defines data members to hold the energy deposit and track lengths
-/// of charged particles in Absober and Gap layers:
-/// - fEnergyAbs, fEnergyGap, fTrackLAbs, fTrackLGap
-/// which are collected step by step via the functions
-/// - AddAbs(), AddGap()
 
 class EventAction : public G4UserEventAction
 {
   public:
-    EventAction();
+    EventAction(RunAction*);
     virtual ~EventAction();
 
     virtual void  BeginOfEventAction(const G4Event* event);
     virtual void    EndOfEventAction(const G4Event* event);
     
-    //void AddAbs(G4double de, G4double dl);
-    //void AddGap(G4double de, G4double dl);
-    
+	 void Add(G4double energy, G4double time, G4int particle, G4double vertex_x, G4double vertex_y, G4double vertex_z, G4double pos_x, G4double pos_y, G4double pos_z, G4int trackId) {
+		 fRunAction->Add(energy, time, particle, vertex_x, vertex_y, vertex_z, pos_x, pos_y, pos_z, trackId);
+	 }
+	 void Clear() {
+		 fRunAction->Clear();
+	 }
   private:
-    //G4double  fEnergyAbs;
-    //G4double  fEnergyGap;
-    //G4double  fTrackLAbs; 
-    //G4double  fTrackLGap;
+	 RunAction* fRunAction;
 };
 
-// inline functions
-
-//inline void B4aEventAction::AddAbs(G4double de, G4double dl) {
-//  fEnergyAbs += de; 
-//  fTrackLAbs += dl;
-//}
-
-//inline void B4aEventAction::AddGap(G4double de, G4double dl) {
-//  fEnergyGap += de; 
-//  fTrackLGap += dl;
-//}
-                     
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 #endif

--- a/include/RunAction.hh
+++ b/include/RunAction.hh
@@ -62,6 +62,44 @@ class RunAction : public G4UserRunAction
 
     virtual void BeginOfRunAction(const G4Run*);
     virtual void   EndOfRunAction(const G4Run*);
+
+	 void Add(G4double energy, G4double time, G4int particle, G4double vertex_x, G4double vertex_y, G4double vertex_z, G4double pos_x, G4double pos_y, G4double pos_z, G4int trackId) {
+		 fEnergy.push_back(energy);
+		 fTime.push_back(time);
+		 fParticle.push_back(particle);
+		 fVertexX.push_back(vertex_x);
+		 fVertexY.push_back(vertex_y);
+		 fVertexZ.push_back(vertex_z);
+		 fPosX.push_back(pos_x);
+		 fPosY.push_back(pos_y);
+		 fPosZ.push_back(pos_z);
+		 fTrackId.push_back(trackId);
+	 }
+
+	 void Clear() {
+		 fEnergy.clear();
+		 fTime.clear();
+		 fParticle.clear();
+		 fVertexX.clear();
+		 fVertexY.clear();
+		 fVertexZ.clear();
+		 fPosX.clear();
+		 fPosY.clear();
+		 fPosZ.clear();
+		 fTrackId.clear();
+	 }
+
+  private:
+	 std::vector<G4double> fEnergy;
+	 std::vector<G4double> fTime;
+	 std::vector<G4int>    fParticle;
+	 std::vector<G4double> fVertexX;
+	 std::vector<G4double> fVertexY;
+	 std::vector<G4double> fVertexZ;
+	 std::vector<G4double> fPosX;
+	 std::vector<G4double> fPosY;
+	 std::vector<G4double> fPosZ;
+	 std::vector<G4int>    fTrackId;
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/src/ActionInitialization.cc
+++ b/src/ActionInitialization.cc
@@ -60,10 +60,11 @@ void ActionInitialization::BuildForMaster() const
 void ActionInitialization::Build() const
 {
   SetUserAction(new PrimaryGeneratorAction);
-  SetUserAction(new RunAction);
-  EventAction* eventAction = new EventAction;
+  RunAction* runAction = new RunAction;
+  SetUserAction(runAction);
+  EventAction* eventAction = new EventAction(runAction);
   SetUserAction(eventAction);
-  SetUserAction(new SteppingAction(fDetConstruction,eventAction));
+  SetUserAction(new SteppingAction(fDetConstruction, eventAction));
 }  
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -148,7 +148,7 @@ G4VPhysicalVolume* DetectorConstruction::DefineVolumes()
   G4Material* tracerMaterial = G4Material::GetMaterial("Tc98_mat");
 
   G4Material* targetMaterial = new G4Material("target_mat", boxMaterial->GetDensity(), 2);
-  double tracerConcentration = 10.*perCent;
+  double tracerConcentration = 90.*perCent;
   targetMaterial->AddMaterial(tracerMaterial, tracerConcentration);
   targetMaterial->AddMaterial(boxMaterial, 100.*perCent - tracerConcentration);
 

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -43,12 +43,8 @@
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-EventAction::EventAction()
- : G4UserEventAction()
-   //fEnergyAbs(0.),
-   //fEnergyGap(0.),
-   //fTrackLAbs(0.),
-   //fTrackLGap(0.)
+EventAction::EventAction(RunAction* runAction)
+ : G4UserEventAction(), fRunAction(runAction)
 {}
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -61,15 +57,12 @@ EventAction::~EventAction()
 void EventAction::BeginOfEventAction(const G4Event* event)
 {  
   // initialisation per event
-  //fEnergyAbs = 0.;
-  //fEnergyGap = 0.;
-  //fTrackLAbs = 0.;
-  //fTrackLGap = 0.;
 
   const G4int numEvents = G4RunManager::GetRunManager()->GetCurrentRun()->GetNumberOfEventToBeProcessed();
   G4int evtN = event->GetEventID();
   if(evtN % 1000 == 0) std::cout << "--> evtN = " << evtN << " ; " << 100*double(evtN)/double(numEvents) << "% done \r" << std::flush;
     
+  fRunAction->Clear();
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -80,40 +73,10 @@ void EventAction::EndOfEventAction(const G4Event* /*event*/)
   //
 
   // get analysis manager
-  //G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();
+  G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();
 
-  // fill histograms
-  //analysisManager->FillH1(1, fEnergyAbs);
-  //analysisManager->FillH1(2, fEnergyGap);
-  //analysisManager->FillH1(3, fTrackLAbs);
-  //analysisManager->FillH1(4, fTrackLGap);
-  
   // fill ntuple
-  //analysisManager->FillNtupleDColumn(0, fEnergyAbs);
-  //analysisManager->FillNtupleDColumn(1, fEnergyGap);
-  //analysisManager->FillNtupleDColumn(2, fTrackLAbs);
-  //analysisManager->FillNtupleDColumn(3, fTrackLGap);
-  //analysisManager->AddNtupleRow();  
-  
-  // Print per event (modulo n)
-  //
-  //G4int eventID = event->GetEventID();
-  //G4int printModulo = G4RunManager::GetRunManager()->GetPrintProgress();
-  //if ( ( printModulo > 0 ) && ( eventID % printModulo == 0 ) ) {
-  //  G4cout << "---> End of event: " << eventID << G4endl;     
-  //
-  //  G4cout
-  //     << "   Absorber: total energy: " << std::setw(7)
-  //                                      << G4BestUnit(fEnergyAbs,"Energy")
-  //     << "       total track length: " << std::setw(7)
-  //                                      << G4BestUnit(fTrackLAbs,"Length")
-  //     << G4endl
-  //     << "        Gap: total energy: " << std::setw(7)
-  //                                      << G4BestUnit(fEnergyGap,"Energy")
-  //     << "       total track length: " << std::setw(7)
-  //                                      << G4BestUnit(fTrackLGap,"Length")
-  //     << G4endl;
-  //}
+  analysisManager->AddNtupleRow();  
 }  
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/src/RunAction.cc
+++ b/src/RunAction.cc
@@ -68,12 +68,16 @@ RunAction::RunAction()
   // Creating ntuple
   //
   analysisManager->CreateNtuple("tree", "gamma ray energy and time");
-  analysisManager->CreateNtupleDColumn("energy");
-  analysisManager->CreateNtupleDColumn("time");
-  analysisManager->CreateNtupleIColumn("particle");
-  analysisManager->CreateNtupleDColumn("vertex_x");
-  analysisManager->CreateNtupleDColumn("vertex_y");
-  analysisManager->CreateNtupleDColumn("vertex_z");
+  analysisManager->CreateNtupleDColumn("energy", fEnergy);
+  analysisManager->CreateNtupleDColumn("time", fTime);
+  analysisManager->CreateNtupleIColumn("particle", fParticle);
+  analysisManager->CreateNtupleDColumn("vertex_x", fVertexX);
+  analysisManager->CreateNtupleDColumn("vertex_y", fVertexY);
+  analysisManager->CreateNtupleDColumn("vertex_z", fVertexZ);
+  analysisManager->CreateNtupleDColumn("pos_x", fPosX);
+  analysisManager->CreateNtupleDColumn("pos_y", fPosY);
+  analysisManager->CreateNtupleDColumn("pos_z", fPosZ);
+  analysisManager->CreateNtupleIColumn("trackId", fTrackId);
   analysisManager->FinishNtuple();
 }
 
@@ -107,36 +111,7 @@ void RunAction::EndOfRunAction(const G4Run* /*run*/)
   // print histogram statistics
   //
   G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();
-  //if ( analysisManager->GetH1(1) ) {
-  //  G4cout << G4endl << " ----> print histograms statistic ";
-  //  if(isMaster) {
-  //    G4cout << "for the entire run " << G4endl << G4endl; 
-  //  }
-  //  else {
-  //    G4cout << "for the local thread " << G4endl << G4endl; 
-  //  }
     
-    //G4cout << " EAbs : mean = " 
-    //   << G4BestUnit(analysisManager->GetH1(1)->mean(), "Energy") 
-    //   << " rms = " 
-    //   << G4BestUnit(analysisManager->GetH1(1)->rms(),  "Energy") << G4endl;
-    
-    //G4cout << " EGap : mean = " 
-    //   << G4BestUnit(analysisManager->GetH1(2)->mean(), "Energy") 
-    //   << " rms = " 
-    //   << G4BestUnit(analysisManager->GetH1(2)->rms(),  "Energy") << G4endl;
-    
-    //G4cout << " LAbs : mean = " 
-    //  << G4BestUnit(analysisManager->GetH1(3)->mean(), "Length") 
-    //  << " rms = " 
-    //  << G4BestUnit(analysisManager->GetH1(3)->rms(),  "Length") << G4endl;
-
-    //G4cout << " LGap : mean = " 
-    //  << G4BestUnit(analysisManager->GetH1(4)->mean(), "Length") 
-    //  << " rms = " 
-    //  << G4BestUnit(analysisManager->GetH1(4)->rms(),  "Length") << G4endl;
-  //}
-
   // save histograms & ntuple
   //
   analysisManager->Write();

--- a/src/SteppingAction.cc
+++ b/src/SteppingAction.cc
@@ -90,43 +90,23 @@ void SteppingAction::UserSteppingAction(const G4Step* step)
 
   //if(particleName == "e-") track->SetTrackStatus(fKillTrackAndSecondaries);
 
-  // vertex
+  // position where the particle is and the vertex of its track
+  G4ThreeVector pos = step->GetPreStepPoint()->GetPosition();
   G4ThreeVector vertex = track->GetVertexPosition();
 
   // particles leaving the box
   if( firstVolume == fDetConstruction->GetBoxPV() && secondVolume == fDetConstruction->GetWorldPV() ) {
-    G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();
-    analysisManager->FillNtupleDColumn(0, ekin/MeV);
-    analysisManager->FillNtupleDColumn(1, time/ms);
-    analysisManager->FillNtupleIColumn(2, particle);
-	 analysisManager->FillNtupleDColumn(3, vertex.x()/mm);
-	 analysisManager->FillNtupleDColumn(4, vertex.y()/mm);
-	 analysisManager->FillNtupleDColumn(5, vertex.z()/mm);
-    analysisManager->AddNtupleRow();
+	  fEventAction->Add(ekin/MeV, time/ns, particle, vertex.x()/mm, vertex.y()/mm, vertex.z()/mm, pos.x()/mm, pos.y()/mm, pos.z()/mm, track->GetTrackID());
   }
 
   // particles entering the target
   if( firstVolume == fDetConstruction->GetBoxPV() && secondVolume == fDetConstruction->GetTargetPV() ) {
-    G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();
-    analysisManager->FillNtupleDColumn(0, ekin/MeV);
-    analysisManager->FillNtupleDColumn(1, time/ms);
-    analysisManager->FillNtupleIColumn(2, 10+particle);
-	 analysisManager->FillNtupleDColumn(3, vertex.x()/mm);
-	 analysisManager->FillNtupleDColumn(4, vertex.y()/mm);
-	 analysisManager->FillNtupleDColumn(5, vertex.z()/mm);
-    analysisManager->AddNtupleRow();
+	  fEventAction->Add(ekin/MeV, time/ns, 10+particle, vertex.x()/mm, vertex.y()/mm, vertex.z()/mm, pos.x()/mm, pos.y()/mm, pos.z()/mm, track->GetTrackID());
   }
 
   // particles leaving the target
   if( firstVolume == fDetConstruction->GetTargetPV() && secondVolume == fDetConstruction->GetBoxPV() ) {
-    G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();
-    analysisManager->FillNtupleDColumn(0, ekin/MeV);
-    analysisManager->FillNtupleDColumn(1, time/ms);
-    analysisManager->FillNtupleIColumn(2, 20+particle);
-	 analysisManager->FillNtupleDColumn(3, vertex.x()/mm);
-	 analysisManager->FillNtupleDColumn(4, vertex.y()/mm);
-	 analysisManager->FillNtupleDColumn(5, vertex.z()/mm);
-    analysisManager->AddNtupleRow();
+	  fEventAction->Add(ekin/MeV, time/ns, 20+particle, vertex.x()/mm, vertex.y()/mm, vertex.z()/mm, pos.x()/mm, pos.y()/mm, pos.z()/mm, track->GetTrackID());
   }
 }
 


### PR DESCRIPTION
- RunAction now has vectors for energy, time, and so on, which are written to the tree.
- EventAction calls RunAction::Clear at the beginning of each event, and writes to the tree at the end of each event.
- EventAction also has two new functions, Clear() and Add(double...), which are just calling the corresponding functions on RunAction to clear the vectors or push back on them.
- SteppingAction only calls the EventAction::Add(double...) function to push back the energy, time, particle ID, vertex position, step position, and track ID.